### PR TITLE
feat: add schema registry ingress, fix readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,7 @@ $RECYCLE.BIN/
 
 # End of https://www.gitignore.io/api/go,helm,linux,macos,windows,eclipse,intellij+all,vim
 gec-iotos-trackntrace/charts
+
+ca.crt
+user.p12
+userpass.txt

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ earthly +kind-recreate-local
 ### get kafka secret
 
 ```shell
-kubectl get secrets -n kafka-lfg kafka-super-user -o jsonpath='{.data.user\.password}' | base64 -d > userpass.txt
+kubectl get secrets -n glue kafka-super-user -o jsonpath='{.data.user\.password}' | base64 -d > userpass.txt
 cat "$(mkcert -CAROOT)/rootCA.pem"  > ca.crt
-kubectl get secrets -n kafka-lfg kafka-super-user -o jsonpath='{.data.ca\.crt}' | base64 -d >> ca.crt
-kubectl get secrets -n kafka-lfg kafka-super-user -o jsonpath='{.data.user\.p12}' | base64 -d > user.p12 
+kubectl get secrets -n glue kafka-super-user -o jsonpath='{.data.ca\.crt}' | base64 -d >> ca.crt
+kubectl get secrets -n glue kafka-super-user -o jsonpath='{.data.user\.p12}' | base64 -d > user.p12 
 ```
 
 ### Kafka Settings for Big Datatools in Intellij
@@ -131,6 +131,7 @@ To access your ingresses you should add them to your /etc/hosts
 127.0.0.1       keycloak.local.lgc
 127.0.0.1       b0.local.lgc
 127.0.0.1       bootstrap.local.lgc
+127.0.0.1       sr.local.lgc
 ```
 
 ### Set Context (also happens after cluster creation)
@@ -181,4 +182,6 @@ const oidcConfig: AuthProviderProps = {
 };
 ```
 
+### Accessing the Schema Registry
 
+The schema registry is available at `https://sr.local.lgc`

--- a/charts/strimzi-registry-operator/templates/_helpers.tpl
+++ b/charts/strimzi-registry-operator/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "strimzi-schema-registry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "strimzi-schema-registry.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "strimzi-schema-registry.labels" -}}
+{{- range $key, $value := .Values.schemaregistry.labels -}}
+{{- printf "%s: %s\n" $key $value }}
+{{- end }}
+{{- end }}
+

--- a/charts/strimzi-registry-operator/templates/ingress.yaml
+++ b/charts/strimzi-registry-operator/templates/ingress.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "strimzi-schema-registry.fullname" . -}}
+{{- $svcName := .Values.service.name -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+  {{- if .Values.schemaregistry }}
+    {{- include .Values.schemaregistry.labels . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ tpl . $ | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ tpl .host $ | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+                port:
+                  number: {{ $svcPort }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/strimzi-registry-operator/templates/ingress.yaml
+++ b/charts/strimzi-registry-operator/templates/ingress.yaml
@@ -17,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Values.ingress.namespace }}
   labels:
   {{- if .Values.schemaregistry }}
     {{- include .Values.schemaregistry.labels . | nindent 4 }}

--- a/charts/strimzi-registry-operator/values.yaml
+++ b/charts/strimzi-registry-operator/values.yaml
@@ -23,6 +23,7 @@ service:
 
 ingress:
   enabled: true
+  namespace: "glue"
   className: ""
   annotations:
     cert-manager.io/cluster-issuer: default-cluster-issuer

--- a/charts/strimzi-registry-operator/values.yaml
+++ b/charts/strimzi-registry-operator/values.yaml
@@ -15,3 +15,23 @@ strimzi-registry-operator:
 
   # -- Namespace where the strimzi-registry-operator is deployed
   operatorNamespace: strimzi-kafka-operator
+
+service:
+  type: ClusterIP
+  port: 8081
+  name: "confluent-schema-registry"
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    cert-manager.io/cluster-issuer: default-cluster-issuer
+  hosts:
+    - host: sr.local.lgc
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: sr-tls
+      hosts:
+        - sr.local.lgc


### PR DESCRIPTION
Adds an ingress to the schema registry so it is accessible via https://sr.local.lgc

Fixes the readme where an old namespace for kafka was used instead of "glue".